### PR TITLE
chore: Add publishConfig to package.json

### DIFF
--- a/packages/gatsby-theme-moltin/package.json
+++ b/packages/gatsby-theme-moltin/package.json
@@ -28,5 +28,8 @@
   },
   "contributors": [
     "Jonathan Steele <jonathan@steele.pro> (https://steele.pro)"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Determine access should be public despite being a scoped package